### PR TITLE
complete: Rename config object to de-conflict with other modules

### DIFF
--- a/scripts/complete.js
+++ b/scripts/complete.js
@@ -1,4 +1,4 @@
-const config = [{
+const conditionAutomationConfig = [{
     name: 'Blinded',
     data: {
         name: 'Blinding Setting',
@@ -26,7 +26,7 @@ const config = [{
 }];
 
 Hooks.once('init', () => {
-    config.forEach((cfg) => {
+    conditionAutomationConfig.forEach((cfg) => {
         game.settings.register('condition-automation', cfg.name, cfg.data);
     });
 });


### PR DESCRIPTION
The JitsiWebRTC module creates a config object with data pulled from a
connected Jitsi server. Unfortunately, we can't easily change the object
name coming from the servers.

Update the object name so it will no longer conflict.

Fixes #18 