### PR TITLE
Tormenta20 support + Portuguese Translation

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,0 +1,16 @@
+{
+  "CONDITION-AUTOMATION.BlindingSettingTitle": "Blinding Setting",
+  "CONDITION-AUTOMATION.BlindingSettingHint": "Toggles the \"blinded\" effect on token vision.",
+  "CONDITION-AUTOMATION.BlindingSettingOption0": "Disabled",
+  "CONDITION-AUTOMATION.BlindingSettingOption1": "1 Degree sight angle",
+  "CONDITION-AUTOMATION.BlindingSettingOption2": "Removes Vision",
+  "CONDITION-AUTOMATION.BlindingSettingOption3": "Perfect Vision limit sight",
+  "CONDITION-AUTOMATION.condition-automationError": "Perfect Vision limit sight cannot work without Perfect Vision enabled.",
+  "CONDITION-AUTOMATION.BlindStatusTitle": "Blind Status Name",
+  "CONDITION-AUTOMATION.BlindStatusHint": "Name of the effect to search for. Default: Blind. For CUB: Blinded.",
+  "CONDITION-AUTOMATION.npcVisionTitle": "Enable unlinked token vision settings",
+  "CONDITION-AUTOMATION.npcVisionHint": "Allows NPCs to be affected by the Blinding Setting.",
+  "CONDITION-AUTOMATION.shadowsTitle": "Shadow Setting",
+  "CONDITION-AUTOMATION.shadowsHint": "Enables the elevation-shadow animation effects.",
+  "CONDITION-AUTOMATION.shadowsError": "Condition Automation shadow effects cannot work without Token Magic FX enabled."
+}

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1,0 +1,16 @@
+{
+  "CONDITION-AUTOMATION.BlindingSettingTitle": "Configuração de Cegueira",
+  "CONDITION-AUTOMATION.BlindingSettingHint": "Alterna o efeito de \"cegueira\" na visão do token.",
+  "CONDITION-AUTOMATION.BlindingSettingOption0": "Desabilitada",
+  "CONDITION-AUTOMATION.BlindingSettingOption1": "Ângulo de Visão de 1 grau",
+  "CONDITION-AUTOMATION.BlindingSettingOption2": "Remove a Visão",
+  "CONDITION-AUTOMATION.BlindingSettingOption3": "Limite de Visão do módulo Perfect Vision",
+  "CONDITION-AUTOMATION.condition-automationError": "Limite de Visão do Perfect Vision não pode funcionar sem o módulo Perfect Vision ativado.",
+  "CONDITION-AUTOMATION.BlindStatusTitle": "Nome do Status de Cegueira",
+  "CONDITION-AUTOMATION.BlindStatusHint": "Nome do efeito que será procurado. Padrão: Blind. Para CUB: Blinded.",
+  "CONDITION-AUTOMATION.npcVisionTitle": "Habilitar configuração de visão para tokens não-vinculados",
+  "CONDITION-AUTOMATION.npcVisionHint": "Permite que NPCs sejam afetados pela Configuração de Cegueira.",
+  "CONDITION-AUTOMATION.shadowsTitle": "Configuração de Sombra",
+  "CONDITION-AUTOMATION.shadowsHint": "Habilita os efeitos de animação de sombra em elevação.",
+  "CONDITION-AUTOMATION.shadowsError": "Efeitos de animação de sombra do Condition Automation não podem funcionar sem o módulo Token Magic FX ativado."
+}

--- a/module.json
+++ b/module.json
@@ -8,11 +8,24 @@
 	"compatibleCoreVersion": "0.7.9",
 	"system": [
 		"dnd5e",
-		"pf2e"
+		"pf2e",
+		"tormenta20"
 	],
 	"scripts": [
 		"scripts/complete.js"
-	], 
+	],
+  "languages": [
+    {
+        "lang": "en",
+        "name": "English",
+        "path": "lang/en.json"
+    },
+    {
+        "lang": "pt-BR",
+        "name": "Português (Brasil)",
+        "path": "lang/pt-BR.json"
+    }
+  ],
 	"url": "https://github.com/kandashi/condition-automation",
 	"manifest": "https://raw.githubusercontent.com/kandashi/condition-automation/master/module.json",
 	"download": "https://github.com/kandashi/condition-automation/archive/master.zip"

--- a/scripts/complete.js
+++ b/scripts/complete.js
@@ -1,70 +1,72 @@
-const conditionAutomationConfig = [{
-    name: 'Blinded',
-    data: {
-        name: 'Blinding Setting',
+Hooks.once('init', () => {
+    let BlindCondition;
+    switch (game.system.id) {
+      case "dnd5e":
+      case "pf2e":
+        BlindCondition = "Blind";
+        break;
+      case "tormenta20":
+        BlindCondition = "Cego";
+        break;
+    }
+    game.settings.register('condition-automation', 'Blinded', 
+    {
+        name: game.i18n.localize("CONDITION-AUTOMATION.BlindingSettingTitle"),
         scope: 'world',
         type: Number,
         default: 0,
         config: true,
-        hint: "Toggles the 'blinded' effect on token vision, setting their vision ark to 1 degree when blinded.",
+        hint: game.i18n.localize("CONDITION-AUTOMATION.BlindingSettingHint"),
         choices: {
-            0: "Disabled",
-            1: "1 Degree sight angle",
-            2: "Removes Vision",
-            3: "Perfect Vision limit sight"
+            0: game.i18n.localize("CONDITION-AUTOMATION.BlindingSettingOption0"),
+            1: game.i18n.localize("CONDITION-AUTOMATION.BlindingSettingOption1"),
+            2: game.i18n.localize("CONDITION-AUTOMATION.BlindingSettingOption2"),
+            3: game.i18n.localize("CONDITION-AUTOMATION.BlindingSettingOption3")
+        },
+        onChange: () => {
+            if (game.settings.get('condition-automation', 'Blinded') === 3 && !game.modules.get("perfect-vision")?.active && game.settings.get('condition-automation', 'shadows')) {
+                ui.notifications.error(game.i18n.localize("CONDITION-AUTOMATION.condition-automationError"))
+            }
         }
-    },
-},
-{
-    name: 'BlindStatus',
-    data: {
-        name: "Blind Status Name",
-        hint: "Name of the effect to search for, default Blinded. For CUB change to Blinded",
+    });
+    game.settings.register('condition-automation', 'BlindStatus', 
+    {
+        name: game.i18n.localize("CONDITION-AUTOMATION.BlindStatusTitle"),
+        hint: game.i18n.localize("CONDITION-AUTOMATION.BlindStatusHint"),
         scope: "world",
         config: true,
-        default: "Blind",
+        default: BlindCondition,
         type: String,
-    }
-},
-{
-    name: 'npcVision',
-    data: {
-        name: 'Enable unlinked token vision settings',
+    });
+    game.settings.register('condition-automation', 'npcVision', 
+    {
+        name: game.i18n.localize("CONDITION-AUTOMATION.npcVisionTitle"),
         scope: 'world',
         type: Boolean,
         default: false,
         config: true,
-        hint: "Allows NPCs to be affected by the blinded setting",
-    }
-},
-{
-    name: 'shadows',
-    data: {
-        name: 'Shadow Setting',
+        hint: game.i18n.localize("CONDITION-AUTOMATION.npcVisionHint"),
+    });
+    game.settings.register('condition-automation', 'shadows', 
+    {
+        name: game.i18n.localize("CONDITION-AUTOMATION.shadowsTitle"),
         scope: 'world',
         type: Boolean,
         default: false,
         config: true,
-        hint: "Toggles the elevation-shadow animation effects.",
+        hint: game.i18n.localize("CONDITION-AUTOMATION.shadowsHint"),
         onChange: () => {
             if (!game.modules.get("tokenmagic")?.active && game.settings.get('condition-automation', 'shadows')) {
-                ui.notifications.error("Condition Automation shadow effects cannot work without Token Magic FX enabled")
+                ui.notifications.error(game.i18n.localize("CONDITION-AUTOMATION.shadowsError"))
             }
         },
-    }
-}];
-
-
-Hooks.once('init', () => {
-    conditionAutomationConfig.forEach((cfg) => {
-        game.settings.register('condition-automation', cfg.name, cfg.data);
     });
 });
 
 console.log("ConditionsV2.1.0 active");
 
 Hooks.on("ready", () => {
-    if (game.system.id === "dnd5e") {
+    if (game.system.id === "dnd5e" || game.system.id === "tormenta20") {
         Hooks.on("preCreateActiveEffect", async (actor, effects, options, someID) => {
             const blindedSetting = game.settings.get('condition-automation', 'Blinded');
             const blindStatus = game.settings.get('condition-automation', 'BlindStatus');
@@ -181,7 +183,7 @@ Hooks.on("ready", () => {
         })
     }
 
-    if (game.system.id === "pf2e") {
+    else if (game.system.id === "pf2e") {
         const itemName = game.settings.get('condition-automation', 'BlindStatus')
         Hooks.on("preUpdateToken", (scene, token, update) => {
             if(game.settings.get('condition-automation', 'npcVision') === false) return;


### PR DESCRIPTION
- Added support for Tormenta20
- Added Localization (English and Portuguese)

Other additions:
- I had to remove the `conditionAutomationConfig` Array for the settings to work with Localization.
- I've took the liberty to update the texts a bit (Blinding Setting Hint's "setting their vision ark to 1 degree when blinded." felt like it was from an outdated version).
- Added a switch to support multiple "Blind" status's names (but didn't reflect that on the localization).
- Added a warning for selecting `Perfect Vision limit sight` while not having the Perfect Vision module active.