### PR TITLE
large re-work with macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
-# Blindness
-Condition Automation will automatically adjust token vision settings to more closely represent Blindness. Configurable settings from removing vision entirely, reducing sight angle to 1 degree or using the Perfect Vivsion module to restrict vision to 0 feet.
+# Condition Management
 
+## Blindness
+Condition Automation will automatically adjust token vision settings to more closely represent Blindness. Configurable settings from removing vision entirely, reducing sight angle to 1 degree or using the Perfect Vision module to restrict vision to 0 feet.
 
-## Shadows
+## Other conditions
+
+Paralyzed, Poisoned, Petrified and Stunned will all trigger a macro as named in the settings. The macro will be called with `arguments[0]` as the token that was effected; and `arguments[1]` as "on" or "off". This will only work for **Linked** tokens at the moment.
+
+## Death macro
+
+A macro can be triggered as a **unlinked** token reaches 0 hp. This is a one way macro and will not re-run if the token is healed.
+
+# Shadows
 This also includes automatic shadow creation for token elevation. This section requires Token Magic Fx to function. Changing the elevation of a token over 5ft will automaticly set a shadow effect "below" the token, this is change in distance based on the elevation value. 
 
 ![Shadow Effects](https://github.com/kandashi/condition-automation/blob/master/Images/ShadowEffects.PNG)
@@ -11,43 +20,3 @@ https://foundryvtt.com/packages/tokenmagic/
 
 
 Many thanks to Forien for guiding me through this module, his patreon is here: https://www.patreon.com/forien
-
-**V1.0.7** Shadow effects updated with "blulge" effect to help show token height, alonside the shadow. Working to query "flying" state before adding shadow effects.
-
-**V1.1.2** Updated Shadow Effects to fall inline with Token Magic FX new system. Updated bulge effects to scale with elevation, alongside the shadow blur increasing with elevation too.
-
-**V1.1.3**
-Updated the conditions to include Paralyzed as an option, thanks to https://github.com/Takryn for bringing this up.
-
-Also included image type independance, now any svg, png, webp or jpg willl register as a valid effect trigger; thanks to https://github.com/dstein766. However this does require the name of the effect to tie into the effect name; you must have the name as the linked status effect for it to register. E.g. eye.png will not registed the blinded condition, but blinded.webp will. The effects are as follows:
-
-* petrified
-* incapacitated
-* restrained
-* grappeled
-* stunned
-* unconscious
-* blinded
-* exhaustion 1-5
-* prone
-For some reason, the default conditions in DnD5e are not recognised.
-
-**V2.0.0**
--Ripped out support for speed changes as this is now supported in the CUB default condition system
-Reworked the blinded setting to properly recognise all Effects not only CUB ones. Now can designate a specific -Effect to trigger the Blind condition
-- Changed config settings to stop collision with the Jitsi Module
-
-**V2.1.0**
-- Added options for Remove Vision from blinded tokens (take care to instruct your players how to reselect their tokens), and also added option to reduce Sight Limit to 0 for those using Perfect Vision
-
-**V2.2.0**
-- Added support for PF2e 
-- Cleaned up old code to enhance performance
-
-**V2.2.4** 
-- Added support for Tormenta (thanks to @mclemente)
-- Added spanish translation (thanks to @mclemente)
-
-**V2.2.5**
-- Added PF1 support
-- Reworked shadow effects to filter out the "bulge" effect as an option

--- a/lang/en.json
+++ b/lang/en.json
@@ -15,5 +15,16 @@
   "CONDITION-AUTOMATION.shadowsError": "Condition Automation shadow effects cannot work without Token Magic FX enabled.",
   "CONDITION-AUTOMATION.shadowsSetting1": "Off",
   "CONDITION-AUTOMATION.shadowsSetting2": "Shadow Only",
-  "CONDITION-AUTOMATION.shadowsSetting3": "All"
+  "CONDITION-AUTOMATION.shadowsSetting3": "All",
+
+  "CONDITION-AUTOMATION.deadMacroName" : "Death Macro",
+  "CONDITION-AUTOMATION.deadMacroHint" : "Name of the macro to execute when an unlinked token hits 0HP",
+  "CONDITION-AUTOMATION.poisonedMacroHint" : "Name of the macro to execute when an token is poisoned",
+  "CONDITION-AUTOMATION.poisonedMacroName" : "Poisoned Macro",
+  "CONDITION-AUTOMATION.stunnedMacroHint" : "Name of the macro to execute when an token is stunned",
+  "CONDITION-AUTOMATION.stunnedMacroName" : "Stunned Macro",
+  "CONDITION-AUTOMATION.paralyzedMacroHint" : "Name of the macro to execute when an token is paralyzed",
+  "CONDITION-AUTOMATION.paralyzedMacroName" : "Paralyzed Macro",
+  "CONDITION-AUTOMATION.petrifiedMacroHint" : "Name of the macro to execute when an token is petrified",
+  "CONDITION-AUTOMATION.petrifiedMacroName" : "Petrified Macro"
 }

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -15,5 +15,16 @@
   "CONDITION-AUTOMATION.shadowsError": "Efeitos de animação de sombra do Condition Automation não podem funcionar sem o módulo Token Magic FX ativado.",
   "CONDITION-AUTOMATION.shadowsSetting1": "[EN] Off",
   "CONDITION-AUTOMATION.shadowsSetting2": "[EN] Shadow Only",
-  "CONDITION-AUTOMATION.shadowsSetting3": "[EN] All"
+  "CONDITION-AUTOMATION.shadowsSetting3": "[EN] All",
+
+  "CONDITION-AUTOMATION.deathMacroName" : "[EN] Death Macro",
+  "CONDITION-AUTOMATION.deathMacroHint" : "[EN] Name of the macro to execute when an unlinked token hits 0HP",
+  "CONDITION-AUTOMATION.poisonedMacroHint" : "[EN] Name of the macro to execute when an token is poisoned",
+  "CONDITION-AUTOMATION.poisonedMacroName" : "[EN] Poisoned Macro",
+  "CONDITION-AUTOMATION.stunnedMacroHint" : "[EN] Name of the macro to execute when an token is stunned",
+  "CONDITION-AUTOMATION.stunnedMacroName" : "[EN] Stunned Macro",
+  "CONDITION-AUTOMATION.paralyzedMacroHint" : "[EN] Name of the macro to execute when an token is paralyzed",
+  "CONDITION-AUTOMATION.paralyzedMacroName" : "[EN] Paralyzed Macro",
+  "CONDITION-AUTOMATION.petrifiedMacroHint" : "[EN] Name of the macro to execute when an token is petrified",
+  "CONDITION-AUTOMATION.petrifiedMacroName" : "[EN] Petrified Macro"
 }

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
 	"title": "Condition Automation",
 	"description": "A simple module to automaticly update token data based on status condtions",
 	"author": "Kandashi",
-	"version": "2.2.6",
+	"version": "3.0.0",
 	"minimumCoreVersion": "0.7.5",
 	"compatibleCoreVersion": "0.7.9",
 	"system": [

--- a/scripts/complete.js
+++ b/scripts/complete.js
@@ -10,26 +10,25 @@ Hooks.once('init', () => {
             break;
     }
 
-    game.settings.register('condition-automation', 'Blinded',
-        {
-            name: game.i18n.localize("CONDITION-AUTOMATION.BlindingSettingTitle"),
-            scope: 'world',
-            type: Number,
-            default: 0,
-            config: true,
-            hint: game.i18n.localize("CONDITION-AUTOMATION.BlindingSettingHint"),
-            choices: {
-                0: game.i18n.localize("CONDITION-AUTOMATION.BlindingSettingOption0"),
-                1: game.i18n.localize("CONDITION-AUTOMATION.BlindingSettingOption1"),
-                2: game.i18n.localize("CONDITION-AUTOMATION.BlindingSettingOption2"),
-                3: game.i18n.localize("CONDITION-AUTOMATION.BlindingSettingOption3")
-            },
-            onChange: () => {
-                if (game.settings.get('condition-automation', 'Blinded') === 3 && !game.modules.get("perfect-vision")?.active && game.settings.get('condition-automation', 'shadows')) {
-                    ui.notifications.error(game.i18n.localize("CONDITION-AUTOMATION.condition-automationError"))
-                }
+    game.settings.register('condition-automation', 'Blinded', {
+        name: game.i18n.localize("CONDITION-AUTOMATION.BlindingSettingTitle"),
+        scope: 'world',
+        type: Number,
+        default: 0,
+        config: true,
+        hint: game.i18n.localize("CONDITION-AUTOMATION.BlindingSettingHint"),
+        choices: {
+            0: game.i18n.localize("CONDITION-AUTOMATION.BlindingSettingOption0"),
+            1: game.i18n.localize("CONDITION-AUTOMATION.BlindingSettingOption1"),
+            2: game.i18n.localize("CONDITION-AUTOMATION.BlindingSettingOption2"),
+            3: game.i18n.localize("CONDITION-AUTOMATION.BlindingSettingOption3")
+        },
+        onChange: () => {
+            if (game.settings.get('condition-automation', 'Blinded') === 3 && !game.modules.get("perfect-vision")?.active && game.settings.get('condition-automation', 'shadows')) {
+                ui.notifications.error(game.i18n.localize("CONDITION-AUTOMATION.condition-automationError"))
             }
-        });
+        }
+    });
     if (game.system.id === "dnd5e" || game.system.id === "pf2e") {
         game.settings.register('condition-automation', 'BlindStatus',
             {
@@ -41,103 +40,132 @@ Hooks.once('init', () => {
                 type: String,
             });
     }
-    game.settings.register('condition-automation', 'npcVision',
-        {
-            name: game.i18n.localize("CONDITION-AUTOMATION.npcVisionTitle"),
-            scope: 'world',
-            type: Boolean,
-            default: false,
-            config: true,
-            hint: game.i18n.localize("CONDITION-AUTOMATION.npcVisionHint"),
-        });
-    game.settings.register('condition-automation', 'shadows',
-        {
-            name: game.i18n.localize("CONDITION-AUTOMATION.shadowsTitle"),
-            scope: 'world',
-            type: String,
-            default: "off",
-            choices: {
-                "off": game.i18n.localize("CONDITION-AUTOMATION.shadowsSetting1"),
-                "shadow": game.i18n.localize("CONDITION-AUTOMATION.shadowsSetting2"),
-                "bulge": game.i18n.localize("CONDITION-AUTOMATION.shadowsSetting3"),
-            },
-            config: true,
-            hint: game.i18n.localize("CONDITION-AUTOMATION.shadowsHint"),
-            onChange: () => {
-                if (!game.modules.get("tokenmagic")?.active && game.settings.get('condition-automation', 'shadows')) {
-                    ui.notifications.error(game.i18n.localize("CONDITION-AUTOMATION.shadowsError"))
-                }
-            },
-        });
+    game.settings.register('condition-automation', 'npcVision', {
+        name: game.i18n.localize("CONDITION-AUTOMATION.npcVisionTitle"),
+        scope: 'world',
+        type: Boolean,
+        default: false,
+        config: true,
+        hint: game.i18n.localize("CONDITION-AUTOMATION.npcVisionHint"),
+    });
+    game.settings.register('condition-automation', 'shadows', {
+        name: game.i18n.localize("CONDITION-AUTOMATION.shadowsTitle"),
+        scope: 'world',
+        type: String,
+        default: "off",
+        choices: {
+            "off": game.i18n.localize("CONDITION-AUTOMATION.shadowsSetting1"),
+            "shadow": game.i18n.localize("CONDITION-AUTOMATION.shadowsSetting2"),
+            "bulge": game.i18n.localize("CONDITION-AUTOMATION.shadowsSetting3"),
+        },
+        config: true,
+        hint: game.i18n.localize("CONDITION-AUTOMATION.shadowsHint"),
+        onChange: () => {
+            if (!game.modules.get("tokenmagic")?.active && game.settings.get('condition-automation', 'shadows')) {
+                ui.notifications.error(game.i18n.localize("CONDITION-AUTOMATION.shadowsError"))
+            }
+        },
+    });
+    game.settings.register('condition-automation', 'deadMacro', {
+        name: game.i18n.localize("CONDITION-AUTOMATION.deadMacroName"),
+        hint: game.i18n.localize("CONDITION-AUTOMATION.deadMacroHint"),
+        type: String,
+        default: "",
+        config: true,
+        scope: 'world'
+    })
+    game.settings.register('condition-automation', 'poisonedMacro', {
+        name: game.i18n.localize("CONDITION-AUTOMATION.poisonedMacroName"),
+        hint: game.i18n.localize("CONDITION-AUTOMATION.poisonedMacroHint"),
+        type: String,
+        default: "",
+        config: true,
+        scope: 'world'
+    })
+    game.settings.register('condition-automation', 'stunnedMacro', {
+        name: game.i18n.localize("CONDITION-AUTOMATION.stunnedMacroName"),
+        hint: game.i18n.localize("CONDITION-AUTOMATION.stunnedMacroHint"),
+        type: String,
+        default: "",
+        config: true,
+        scope: 'world'
+    })
+    game.settings.register('condition-automation', 'paralyzedMacro', {
+        name: game.i18n.localize("CONDITION-AUTOMATION.paralyzedMacroName"),
+        hint: game.i18n.localize("CONDITION-AUTOMATION.paralyzedMacroHint"),
+        type: String,
+        default: "",
+        config: true,
+        scope: 'world'
+    })
+    game.settings.register('condition-automation', 'petrifiedMacro', {
+        name: game.i18n.localize("CONDITION-AUTOMATION.petrifiedMacroName"),
+        hint: game.i18n.localize("CONDITION-AUTOMATION.petrifiedMacroHint"),
+        type: String,
+        default: "",
+        config: true,
+        scope: 'world'
+    })
 });
 
 console.log("ConditionsV2.2.6 active");
 
 Hooks.on("ready", () => {
-    if(!game.user === game.users.find((u) => u.isGM && u.active)) return;
+    if (!game.user === game.users.find((u) => u.isGM && u.active)) return;
     if (game.system.id === "dnd5e" || game.system.id === "tormenta20") {
-        Hooks.on("preCreateActiveEffect", async (actor, effects, options, someID) => {
-            const blindedSetting = game.settings.get('condition-automation', 'Blinded');
+        Hooks.on("preCreateActiveEffect", async (actor, effects) => {
             const blindStatus = game.settings.get('condition-automation', 'BlindStatus');
             let blinded = effects.label === blindStatus;
-            let token = actor.getActiveTokens()[0]
-            let actorToken = game.actors.get(actor.data._id)
+            const poisoned = effects.label === game.i18n.format("DND5E.ConPoisoned")
+            const stunned = effects.label === game.i18n.format("DND5E.ConStunned")
+            const paralyzed = effects.label === game.i18n.format("DND5E.ConParalyzed")
+            const petrified = effects.label === game.i18n.format("DND5E.ConPetrified")
             if (blinded) {
-                switch (blindedSetting) {
-                    case 1: {
-                        actorToken.setFlag('condition-automation', 'sightAngleOld', actorToken.data.token.sightAngle)
-                        token.update({ "sightAngle": 1 });
-                        actorToken.update({ "token.sightAngle": 1 })
-                    }
-                        break;
-                    case 2: {
-                        token.update({ "vision": false });
-                        actorToken.update({ "token.vision": false })
-                    }
-                        break;
-                    case 3: {
-                        let oldVision = token.getFlag('perfect-vision', 'sightLimit');
-                        token.setFlag('condition-automation', 'PVold', oldVision);
-                        token.setFlag('perfect-vision', 'sightLimit', 0);
-                        actorToken.setFlag('perfect-vision', 'sightLimit', 0);
-                    }
-                        break;
-                }
+                ConAutoDND.blindApplyActor(actor)
+            }
+            if(poisoned) {
+                let token = actor.getActiveTokens()[0]
+                ConAuto.poisoned(token)
+            }
+            if(stunned) {
+                let token = actor.getActiveTokens()[0]
+                ConAuto.stunned(token)
+            }
+            if(paralyzed) {
+                let token = actor.getActiveTokens()[0]
+                ConAuto.paralyzed(token)
+            }
+            if(petrified) {
+                let token = actor.getActiveTokens()[0]
+                ConAuto.petrified(token)
             }
         });
 
-        Hooks.on("preDeleteActiveEffect", async (actor, effects, options, someID) => {
-            const blindedSetting = game.settings.get('condition-automation', 'Blinded');
+        Hooks.on("preDeleteActiveEffect", async (actor, effects) => {
             const blindStatus = game.settings.get('condition-automation', 'BlindStatus');
             let blinded = effects.label === blindStatus;
-            let token = actor.getActiveTokens()[0]
-            let actorToken = game.actors.get(actor.data._id)
+            const poisoned = effects.label === game.i18n.format("DND5E.ConPoisoned")
+            const stunned = effects.label === game.i18n.format("DND5E.ConStunned")
+            const paralyzed = effects.label === game.i18n.format("DND5E.ConParalyzed")
+            const petrified = effects.label === game.i18n.format("DND5E.ConPetrified")
             if (blinded) {
-                switch (blindedSetting) {
-                    case 1: {
-                        let visionArc = actorToken.getFlag('condition-automation', 'sightAngleOld')
-                        token.update({ "sightAngle": visionArc });
-                        actorToken.update({ "token.sightAngle": visionArc })
-                    }
-                        break;
-                    case 2: {
-                        token.update({ "vision": true });
-                        actorToken.update({ "token.vision": true })
-                    }
-                        break;
-                    case 3: {
-                        let oldVision = token.getFlag('condition-automation', 'PVold');
-                        if (oldVision) {
-                            token.setFlag('perfect-vision', 'sightLimit', oldVision);
-                            actorToken.setFlag('perfect-vision', 'sightLimit', oldVision);
-                        }
-                        else {
-                            token.unsetFlag('perfect-vision', 'sightLimit');
-                            actorToken.unsetFlag('perfect-vision', 'sightLimit');
-                        }
-                        break;
-                    }
-                }
+                ConAutoDND.blindRemoveActor(actor)
+            }
+            if(poisoned) {
+                let token = actor.getActiveTokens()[0]
+                ConAuto.poisoned(token)
+            }
+            if(stunned) {
+                let token = actor.getActiveTokens()[0]
+                ConAuto.stunned(token)
+            }
+            if(paralyzed) {
+                let token = actor.getActiveTokens()[0]
+                ConAuto.paralyzed(token)
+            }
+            if(petrified) {
+                let token = actor.getActiveTokens()[0]
+                ConAuto.petrified(token)
             }
         })
 
@@ -249,123 +277,68 @@ Hooks.on("ready", () => {
         })
 
         Hooks.on("createOwnedItem", (actor, item) => {
-            let test;
             if (item.type === 'condition' && item.flags[game.system.id]?.condition && item.name === `${itemName}`) {
-                const blindedSetting = game.settings.get('condition-automation', 'Blinded');
                 const token = actor.getActiveTokens()[0]
                 const blinded = actor.getFlag('condition-automation', 'sight')
                 if (!blinded) {
-                    switch (blindedSetting) {
-                        case 1: {
-                            let visionArc = token.data.sightAngle
-                            actor.setFlag('condition-automation', 'sight', visionArc)
-                            token.update({ "sightAngle": 1 });
-                        }
-                            break;
-                        case 2: {
-                            actor.setFlag('condition-automation', 'sight', 1)
-                            token.update({ "vision": false });
-                        }
-                            break;
-                        case 3: {
-                            let oldVision = token.getFlag('perfect-vision', 'sightLimit');
-                            actor.setFlag('condition-automation', 'sight', oldVision);
-                            token.setFlag('perfect-vision', 'sightLimit', 0);
-                        }
-                            break;
-                    }
+                    ConAutoPF2.blindApplyActor(actor, token)
                 }
+            }
+            if (item.type === 'condition' && item.flags[game.system.id]?.condition && item.name === game.i18n.format("PF2E.ConditionTypeSickened")) {
+                ConAuto.poisoned(actor.getActiveTokens()[0])
+            }
+            if (item.type === 'condition' && item.flags[game.system.id]?.condition && item.name === game.i18n.format("PF2E.ConditionTypeStunned")) {
+                ConAuto.stunned(actor.getActiveTokens()[0])
+            }
+            if (item.type === 'condition' && item.flags[game.system.id]?.condition && item.name === game.i18n.format("PF2E.ConditionTypePetrified")) {
+                ConAuto.petrified(actor.getActiveTokens()[0])
+            }
+            if (item.type === 'condition' && item.flags[game.system.id]?.condition && item.name === game.i18n.format("PF2E.ConditionTypeParalyzed")) {
+                ConAuto.paralyzed(actor.getActiveTokens()[0])
             }
         });
 
         Hooks.on("deleteOwnedItem", (actor, item) => {
-            let test;
             if (item.type === 'condition' && item.flags[game.system.id]?.condition && item.name === `${itemName}`) {
-                const blindedSetting = game.settings.get('condition-automation', 'Blinded');
                 const token = actor.getActiveTokens()[0]
                 const blinded = actor.getFlag('condition-automation', 'sight')
                 if (blinded) {
-                    switch (blindedSetting) {
-                        case 1: {
-                            let visionArc = actor.getFlag('condition-automation', 'sight')
-                            actor.unsetFlag('condition-automation', 'sight')
-                            token.update({ "sightAngle": visionArc });
-                        }
-                            break;
-                        case 2: {
-                            actor.unsetFlag('condition-automation', 'sight')
-                            token.update({ "vision": true });
-                        }
-                            break;
-                        case 3: {
-                            let oldVision = actor.getFlag('condition-automation', 'sight');
-                            actor.unsetFlag('condition-automation', 'sight');
-                            token.setFlag('perfect-vision', 'sightLimit', oldVision);
-                        }
-                            break;
-                    }
+                    ConAutoPF2.blindRemoveActor(actor, token)
                 }
+            }
+            if (item.type === 'condition' && item.flags[game.system.id]?.condition && item.name === game.i18n.format("PF2E.ConditionTypeSickened")) {
+                ConAuto.poisoned(actor.getActiveTokens()[0])
+            }
+            if (item.type === 'condition' && item.flags[game.system.id]?.condition && item.name === game.i18n.format("PF2E.ConditionTypeStunned")) {
+                ConAuto.stunned(actor.getActiveTokens()[0])
+            }
+            if (item.type === 'condition' && item.flags[game.system.id]?.condition && item.name === game.i18n.format("PF2E.ConditionTypePetrified")) {
+                ConAuto.petrified(actor.getActiveTokens()[0])
+            }
+            if (item.type === 'condition' && item.flags[game.system.id]?.condition && item.name === game.i18n.format("PF2E.ConditionTypeParalyzed")) {
+                ConAuto.paralyzed(actor.getActiveTokens()[0])
             }
         })
     }
 
     if (game.system.id === "pf1") {
         Hooks.on("updateActor", (actor, update) => {
-            const blindedSetting = game.settings.get('condition-automation', 'Blinded');
             let blind = getProperty(update, "data.attributes.conditions.blind")
-            if (blind === undefined) return;
-            let tokenArray = actor.getActiveTokens()
-            if (blind === true) {
-                switch (blindedSetting) {
-                    case 1: {
-                        actor.setFlag('condition-automation', 'sightAngleOld', actor.data.token.sightAngle)
-                        for (let token of tokenArray) token.update({ "sightAngle": 1 });
-                        actor.update({ "token.sightAngle": 1 })
-                    }
-                        break;
-                    case 2: {
-                        for (let token of tokenArray) token.update({ "vision": false });
-                        actorToken.update({ "token.vision": false })
-                    }
-                        break;
-                    case 3: {
-                        for (let token of tokenArray) {
-                            let oldVision = token.getFlag('perfect-vision', 'sightLimit');
-                            token.setFlag('condition-automation', 'PVold', oldVision);
-                            token.setFlag('perfect-vision', 'sightLimit', 0);
-                        }
-                        actor.setFlag('perfect-vision', 'sightLimit', 0);
-                    }
-                        break;
-                }
+            let stunned = getProperty(update, "data.attributes.conditions.stunned")
+            let poisoned = getProperty(update, "data.attributes.conditions.poisoned")
+            let paralyzed = getProperty(update, "data.attributes.conditions.paralyzed")
+            let petrified = getProperty(update, "data.attributes.conditions.petrified")
+            if (blind) {
+                ConAutoPF1.blindApplyActor(actor)
             }
-            if (blind === false) {
-                switch (blindedSetting) {
-                    case 1: {
-                        let visionArc = actor.getFlag('condition-automation', 'sightAngleOld')
-                        for (let token of tokenArray) token.update({ "sightAngle": visionArc });
-                        actor.update({ "token.sightAngle": visionArc })
-                    }
-                        break;
-                    case 2: {
-                        for (let token of tokenArray) token.update({ "vision": true });
-                        actorToken.update({ "token.vision": true })
-                    }
-                        break;
-                    case 3: {
-                        for (let token of tokenArray) {
-                            let oldVision = token.getFlag('condition-automation', 'PVold');
-                            if (oldVision) { token.setFlag('perfect-vision', 'sightLimit', oldVision); }
-                            else { token.unsetFlag('perfect-vision', 'sightLimit'); }
-                        }
-
-                        if (oldVision) {
-                            actor.setFlag('perfect-vision', 'sightLimit', oldVision);
-                        } else { actor.unsetFlag('perfect-vision', 'sightLimit'); }
-                        break;
-                    }
-                }
+            else if (!blind) {
+                ConAutoPF1.blindRemoveActor(actor)
             }
+            let token = actor.getActiveTokens()[0]
+            if(stunned !== undefined) ConAuto.stunned(token)
+            if(poisoned !== undefined) ConAuto.poisoned(token)
+            if(paralyzed !== undefined) ConAuto.paralyzed(token)
+            if(petrified  !== undefined) ConAuto.petrified(token)
         })
 
         Hooks.on("preUpdateToken", (_scene, token, update) => {
@@ -418,12 +391,31 @@ Hooks.on("ready", () => {
     }
 });
 
-Hooks.on("preUpdateToken", async (scene, token, updateData, options) => {
+Hooks.on("preUpdateToken", async (_scene, token, updateData) => {
+
     const shadowSetting = game.settings.get('condition-automation', 'shadows');
-    let elevation = getProperty(updateData, "elevation");
-    let tokenInstance = canvas.tokens.get(token._id);
-    let CAEffectId = "CondtionAutomationShadows"
-    let bulge1 =
+    const elevation = getProperty(updateData, "elevation");
+    let systemPath = ConAuto.systemPaths()
+    const hp = getProperty(updateData, systemPath.HP)
+    if (elevation !== undefined && shadowSetting !== "off") ConAuto.shadowEffect(token._id, elevation)
+    if (hp === 0 && game.settings.get('condition-automation', 'deadMacro') !== "") ConAuto.deathEffect(token._id)
+
+});
+
+class ConAuto {
+
+    static systemPaths() {
+        switch (game.system.id) {
+            case "dnd5e": return { HP: "actorData.data.attributes.hp.value" };
+            case "pf2e" : return {HP: "actorData.data.attributes.hp.value"};
+            case "pf1" : return {HP: "actorData.data.attributes.hp.value"};
+        }
+    }
+
+    static async shadowEffect(tokenID, elevation) {
+        let tokenInstance = canvas.tokens.get(tokenID);
+        let CAEffectId = "ConditionAutomationShadows"
+        let bulge1 =
         {
             filterType: "twist",
             filterId: CAEffectId,
@@ -443,7 +435,7 @@ Hooks.on("preUpdateToken", async (scene, token, updateData, options) => {
                 }
             }
         }
-        let bulge2 =
+        let bulge2 = 
         {
             filterType: "bulgepinch",
             filterId: CAEffectId,
@@ -464,56 +456,251 @@ Hooks.on("preUpdateToken", async (scene, token, updateData, options) => {
                 }
             }
         }
-    let shadow = {
-        filterType: "shadow",
-        filterId: CAEffectId,
-        rotation: 35,
-        autoDestroy: true,
-        blur: 2,
-        quality: 5,
-        distance: elevation,
-        alpha: 0.33,
-        padding: 10,
-        shadowOnly: false,
-        color: 0x000000,
-        animated:
-        {
-            blur:
+        let shadow = {
+            filterType: "shadow",
+            filterId: CAEffectId,
+            rotation: 35,
+            autoDestroy: true,
+            blur: 2,
+            quality: 5,
+            distance: elevation*1.5,
+            alpha: 0.33,
+            padding: 10,
+            shadowOnly: false,
+            color: 0x000000,
+            animated:
             {
-                active: true,
-                loopDuration: 6000,
-                animType: "syncCosOscillation",
-                val1: 2,
-                val2: 3
-            },
-            distance:
-            {
-                active: true,
-                loopDuration: 6000,
-                animType: "syncSinOscillation",
-                val1: 75,
-                val2: 80
-            },
-            alpha:
-            {
-                active: true,
-                loopDuration: 6000,
-                animType: "syncSinOscillation",
-                val1: .33,
-                val2: .2
+                blur:
+                {
+                    active: true,
+                    loopDuration: 500,
+                    animType: "syncCosOscillation",
+                    val1: 1,
+                    val2: 0.5
+                },
+                distance:
+                {
+                    active: true,
+                    loopDuration: 6000,
+                    animType: "syncSinOscillation",
+                    val1: elevation*1.5,
+                    val2: elevation*1.5 + 5
+                },
+                alpha:
+                {
+                    active: true,
+                    loopDuration: 6000,
+                    animType: "syncSinOscillation",
+                    val1: .33,
+                    val2: .2
+                }
+            }
+        };
+        const shadowSetting = game.settings.get('condition-automation', 'shadows');
+        let params = [shadow]
+        if (shadowSetting === "bulge") params = [shadow, bulge1, /*bulge2*/]
+
+        let filter = (elevation > 5) ? true : false;
+        console.log(params)
+        await tokenInstance.TMFXdeleteFilters(CAEffectId)
+        if (filter) {
+            await TokenMagic.addUpdateFilters(tokenInstance, params);
+        }
+    }
+
+    static deathEffect(tokenID) {
+        let macro = game.macros.getName(game.settings.get('condition-automation', 'deadMacro'))
+        let token = canvas.tokens.get(tokenID)
+        if (!macro || !token) console.log("Condition Automation: No macro or token found")
+        macro.execute(token)
+    }
+
+    static poisoned(token){
+        let macro = game.macros.getName(game.settings.get('condition-automation', 'poisonedMacro'))
+        if (!macro || !token) console.log("Condition Automation: No macro or token found")
+        macro.execute(token)
+    }
+    static stunned(token){
+        let macro = game.macros.getName(game.settings.get('condition-automation', 'stunnedMacro'))
+        if (!macro || !token) console.log("Condition Automation: No macro or token found")
+        macro.execute(token)
+    }
+    static paralyzed(token){
+        let macro = game.macros.getName(game.settings.get('condition-automation', 'paralyzedMacro'))
+        if (!macro || !token) console.log("Condition Automation: No macro or token found")
+        macro.execute(token)
+    }
+    static petrified(token){
+        let macro = game.macros.getName(game.settings.get('condition-automation', 'petrifiedMacro'))
+        if (!macro || !token) console.log("Condition Automation: No macro or token found")
+        macro.execute(token)
+    }
+}
+
+class ConAutoPF1 {
+    static async blindApplyActor(actor) {
+        let tokenArray = actor.getActiveTokens()
+        const blindedSetting = game.settings.get('condition-automation', 'Blinded');
+        switch (blindedSetting) {
+            case 1: {
+                actor.setFlag('condition-automation', 'sightAngleOld', actor.data.token.sightAngle)
+                for (let token of tokenArray) token.update({ "sightAngle": 1 });
+                actor.update({ "token.sightAngle": 1 })
+            }
+                break;
+            case 2: {
+                for (let token of tokenArray) token.update({ "vision": false });
+                actorToken.update({ "token.vision": false })
+            }
+                break;
+            case 3: {
+                for (let token of tokenArray) {
+                    let oldVision = token.getFlag('perfect-vision', 'sightLimit');
+                    token.setFlag('condition-automation', 'PVold', oldVision);
+                    token.setFlag('perfect-vision', 'sightLimit', 0);
+                }
+                actor.setFlag('perfect-vision', 'sightLimit', 0);
+            }
+                break;
+        }
+    }
+    static async blindRemoveActor(actor) {
+        let tokenArray = actor.getActiveTokens()
+        const blindedSetting = game.settings.get('condition-automation', 'Blinded');
+        switch (blindedSetting) {
+            case 1: {
+                let visionArc = actor.getFlag('condition-automation', 'sightAngleOld')
+                for (let token of tokenArray) token.update({ "sightAngle": visionArc });
+                actor.update({ "token.sightAngle": visionArc })
+            }
+                break;
+            case 2: {
+                for (let token of tokenArray) token.update({ "vision": true });
+                actorToken.update({ "token.vision": true })
+            }
+                break;
+            case 3: {
+                for (let token of tokenArray) {
+                    let oldVision = token.getFlag('condition-automation', 'PVold');
+                    if (oldVision) { token.setFlag('perfect-vision', 'sightLimit', oldVision); }
+                    else { token.unsetFlag('perfect-vision', 'sightLimit'); }
+                }
+
+                if (oldVision) {
+                    actor.setFlag('perfect-vision', 'sightLimit', oldVision);
+                } else { actor.unsetFlag('perfect-vision', 'sightLimit'); }
+                break;
             }
         }
-    };
-    if (elevation === undefined || shadowSetting === "off") {
-        return;
     }
-    let params = [shadow]
-    if(shadowSetting === "bulge") params = [shadow, bulge1, bulge2]
+}
 
-    let filter = (elevation > 5) ? true : false;
-    console.log(params)
-    await tokenInstance.TMFXdeleteFilters(CAEffectId)
-    if (filter) {
-        await TokenMagic.addUpdateFilters(tokenInstance, params);
+class ConAutoPF2 {
+
+    static blindApplyActor(actor, token){
+        const blindedSetting = game.settings.get('condition-automation', 'Blinded');
+        switch (blindedSetting) {
+            case 1: {
+                let visionArc = token.data.sightAngle
+                actor.setFlag('condition-automation', 'sight', visionArc)
+                token.update({ "sightAngle": 1 });
+            }
+                break;
+            case 2: {
+                actor.setFlag('condition-automation', 'sight', 1)
+                token.update({ "vision": false });
+            }
+                break;
+            case 3: {
+                let oldVision = token.getFlag('perfect-vision', 'sightLimit');
+                actor.setFlag('condition-automation', 'sight', oldVision);
+                token.setFlag('perfect-vision', 'sightLimit', 0);
+            }
+                break;
+        }
     }
-});
+
+    static blindRemoveActor(actor, token){
+        const blindedSetting = game.settings.get('condition-automation', 'Blinded');
+        switch (blindedSetting) {
+            case 1: {
+                let visionArc = actor.getFlag('condition-automation', 'sight')
+                actor.unsetFlag('condition-automation', 'sight')
+                token.update({ "sightAngle": visionArc });
+            }
+                break;
+            case 2: {
+                actor.unsetFlag('condition-automation', 'sight')
+                token.update({ "vision": true });
+            }
+                break;
+            case 3: {
+                let oldVision = actor.getFlag('condition-automation', 'sight');
+                actor.unsetFlag('condition-automation', 'sight');
+                token.setFlag('perfect-vision', 'sightLimit', oldVision);
+            }
+                break;
+        }
+    }
+}
+
+class ConAutoDND {
+
+    static blindApplyActor(actor) {
+        const blindedSetting = game.settings.get('condition-automation', 'Blinded');
+        let token = actor.getActiveTokens()[0]
+        let actorToken = game.actors.get(actor.data._id)
+        switch (blindedSetting) {
+            case 1: {
+                actorToken.setFlag('condition-automation', 'sightAngleOld', actorToken.data.token.sightAngle)
+                token.update({ "sightAngle": 1 });
+                actorToken.update({ "token.sightAngle": 1 })
+            }
+                break;
+            case 2: {
+                token.update({ "vision": false });
+                actorToken.update({ "token.vision": false })
+            }
+                break;
+            case 3: {
+                let oldVision = token.getFlag('perfect-vision', 'sightLimit');
+                token.setFlag('condition-automation', 'PVold', oldVision);
+                token.setFlag('perfect-vision', 'sightLimit', 0);
+                actorToken.setFlag('perfect-vision', 'sightLimit', 0);
+            }
+                break;
+        }
+    }
+
+    static blindRemoveActor(actor){
+        const blindedSetting = game.settings.get('condition-automation', 'Blinded');
+        let token = actor.getActiveTokens()[0]
+        let actorToken = game.actors.get(actor.data._id)
+        switch (blindedSetting) {
+            case 1: {
+                let visionArc = actorToken.getFlag('condition-automation', 'sightAngleOld')
+                token.update({ "sightAngle": visionArc });
+                actorToken.update({ "token.sightAngle": visionArc })
+            }
+                break;
+            case 2: {
+                token.update({ "vision": true });
+                actorToken.update({ "token.vision": true })
+            }
+                break;
+            case 3: {
+                let oldVision = token.getFlag('condition-automation', 'PVold');
+                if (oldVision) {
+                    token.setFlag('perfect-vision', 'sightLimit', oldVision);
+                    actorToken.setFlag('perfect-vision', 'sightLimit', oldVision);
+                }
+                else {
+                    token.unsetFlag('perfect-vision', 'sightLimit');
+                    actorToken.unsetFlag('perfect-vision', 'sightLimit');
+                }
+                break;
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Other conditions

Paralyzed, Poisoned, Petrified and Stunned will all trigger a macro as named in the settings. The macro will be called with `arguments[0]` as the token that was effected; and `arguments[1]` as "on" or "off". This will only work for **Linked** tokens at the moment.

## Death macro

A macro can be triggered as a **unlinked** token reaches 0 hp. This is a one way macro and will not re-run if the token is healed.
